### PR TITLE
Add a --noBackups command-line option

### DIFF
--- a/Bethini.pyw
+++ b/Bethini.pyw
@@ -644,22 +644,23 @@ class bethini_app(ttk.Window):
                         int(cast("str", ModifyINI.app_config().get_value("General", "iMaxBackups", "5"))),
                         files_to_remove,
                     )
-                    if ini_location in locations_without_first_backup:
-                        locations_without_first_backup.remove(ini_location)
-                        self.create_first_time_backup(ini_location, inis_by_location[ini_location])
+                    if self.makeBackups:
+                        if ini_location in locations_without_first_backup and self.makeBackups:
+                            locations_without_first_backup.remove(ini_location)
+                            self.create_first_time_backup(ini_location, inis_by_location[ini_location])
 
-                    current_backup_path = backups_path / LOG_DIR_DATE
-                    current_backup_path.mkdir(parents=True, exist_ok=True)
-                    current_backup_file_path = current_backup_path / ini_object.ini_path.name
-                    if current_backup_file_path.exists():
-                        logger.warning(f"{current_backup_file_path} already exists, so it will not be overwritten.")
-                    else:
-                        try:
-                            copyfile(ini_object.ini_path, current_backup_file_path)
-                        except FileNotFoundError as e:
-                            logger.exception(
-                                f"{ini_object.ini_path} does not exist, so it cannot be backed up. This is typically caused by a path not being set correctly."
-                            )
+                        current_backup_path = backups_path / LOG_DIR_DATE
+                        current_backup_path.mkdir(parents=True, exist_ok=True)
+                        current_backup_file_path = current_backup_path / ini_object.ini_path.name
+                        if current_backup_file_path.exists():
+                            logger.warning(f"{current_backup_file_path} already exists, so it will not be overwritten.")
+                        else:
+                            try:
+                                copyfile(ini_object.ini_path, current_backup_file_path)
+                            except FileNotFoundError as e:
+                                logger.exception(
+                                    f"{ini_object.ini_path} does not exist, so it cannot be backed up. This is typically caused by a path not being set correctly."
+                                )
                     try:
                         ini_object.save_ini_file(sort=save_dialog.sort)
                         file_saved = True
@@ -689,7 +690,8 @@ class bethini_app(ttk.Window):
                             file_saved = False
                     if file_saved:
                         self.sme(f"{ini_object.ini_path} saved.")
-                        copyfile(APP_LOG_FILE, current_backup_path / APP_LOG_FILE.name)
+                        if self.makeBackups:
+                            copyfile(APP_LOG_FILE, current_backup_path / APP_LOG_FILE.name)
 
 
         if not files_saved:

--- a/Bethini.pyw
+++ b/Bethini.pyw
@@ -12,6 +12,7 @@ import math
 import os
 import sys
 import tkinter as tk
+import argparse
 from collections.abc import Sequence
 from datetime import datetime
 from operator import eq, ge, gt, le, lt, ne
@@ -126,6 +127,11 @@ class bethini_app(ttk.Window):
                          themename=themename,
                          iconphoto="Icons/Icon.png",
                          minsize=(400, 200))
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--noBackups', action='store_true')
+        args, _ = parser.parse_known_args()
+        self.makeBackups = not args.noBackups
 
         CustomFunctions.screenwidth = self.winfo_screenwidth()
         CustomFunctions.screenheight = self.winfo_screenheight()

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## About
 Bethini Pie is an INI editor designed to allow advanced customization of game configuration settings.
 
+## Command-line Options
+
+`--noBackups` - does not create any backup files or directories
+
 ## Ressources
 - Official Download Page on Nexus Mods: https://www.nexusmods.com/site/mods/631/
 - Bethini Support on STEP Forums: https://stepmodifications.org/forum/forum/200-bethini-support/


### PR DESCRIPTION
This is mostly for me, although I hope it's useful for others.

I'm using git to version control the INIs so I don't need backups. Also, Wabbajack's `ignore` feature is not very flexible, so all those `*.BethINIbackup` files and backup folders were creeping into my Wabbajack file, this helps keeps stuff clean.

A command-line option that doesn't change behavior if not set seems the right way to implement this.